### PR TITLE
fix: Update email link to new gmail service

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -90,7 +90,7 @@ var UI = new function() {
 			        .attr('title', _('__MAIL__'));
 		}
 		$('#button_mail').unbind( "click" ).click(function() {
-			open_tab('/WebMail/attach.do', null, true);
+			open_tab('https://mail.google.com/a/uoc.edu');
 		});
 
 		$('#update').unbind( "click" ).click( function() {


### PR DESCRIPTION
The university switched to a new gmail service for emails, but the quick access link in the Chrome extension still directed users to the old email service. This commit fixes the issue by updating the link to the new gmail service, ensuring a seamless user experience.